### PR TITLE
Attempt to configure datasource for logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Commands are intended to be run in the cloned repository root.
 
 Configure the index in kibana by going to `Stack Management` -> `Data Views`.
 
-Create a data view for the `logstash` index to visualize the logs from all the docker containers.
+Create a data view for the `logstash-*` index to visualize the logs from all the docker containers.
 
 ## Grafana
 

--- a/logs/logstash.conf
+++ b/logs/logstash.conf
@@ -14,6 +14,6 @@ filter {
 output {
   elasticsearch {
     hosts => ["elasticsearch:9200"]
-    index => "logstash"
+    index => "logstash-%{+YYYY-MM-dd}"
   }
 }

--- a/logs/logstash.conf
+++ b/logs/logstash.conf
@@ -9,6 +9,10 @@ filter {
     source => "message"
     skip_on_invalid_json => true
   }
+
+  if [level] not in ["debug", "verbose", "info", "warn", "error"] {
+    drop {}
+  }
 }
 
 output {

--- a/logs/logstash.conf
+++ b/logs/logstash.conf
@@ -10,7 +10,7 @@ filter {
     skip_on_invalid_json => true
   }
 
-  if [level] not in ["debug", "verbose", "info", "warn", "error"] {
+  if [log.level] not in ["debug", "verbose", "info", "warn", "error"] {
     drop {}
   }
 }

--- a/metrics/datasource.yml
+++ b/metrics/datasource.yml
@@ -10,3 +10,15 @@ datasources:
     isDefault: true
     editable: false
     version: 1
+
+  - name: 'Logs'
+    type: 'elasticsearch'
+    access: 'proxy'
+    database: '[logstash-]YYYY.MM.DD'
+    url: 'http://elasticsearch:9200'
+    jsonData:
+      interval: 'Daily'
+      timeField: '@timestamp'
+      esVersion: '8.4.1'
+      logMessageField: message
+      logLevelField: fields.level

--- a/metrics/datasource.yml
+++ b/metrics/datasource.yml
@@ -20,5 +20,6 @@ datasources:
       interval: 'Daily'
       timeField: '@timestamp'
       esVersion: '8.4.1'
-      logMessageField: message
-      logLevelField: fields.level
+      logMessageField: 'message'
+      logLevelField: 'level'
+    editable: false

--- a/metrics/datasource.yml
+++ b/metrics/datasource.yml
@@ -14,7 +14,7 @@ datasources:
   - name: 'Logs'
     type: 'elasticsearch'
     access: 'proxy'
-    database: '[logstash-]YYYY.MM.DD'
+    database: '[logstash-]YYYY-MM-DD'
     url: 'http://elasticsearch:9200'
     jsonData:
       interval: 'Daily'


### PR DESCRIPTION
# What

Introduce datasource for grafana from logs stored in elasticsearch.

# Bug Fix

The logstash filter was intended to filter out any logs that weren't JSON, but it wasn't doing this because we weren't using the [drop](https://www.elastic.co/guide/en/logstash/current/plugins-filters-drop.html) filter.

# Query

When we're ready to create charts from the logs datasource, we must use the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html).